### PR TITLE
Add Xdebug instruction 

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -16,6 +16,9 @@ INSTALLED_REPOS="magento2ce inventory magento2-sample-data services-connector da
 INSTALLED_REPOS_EE="magento2ce inventory magento2ee magento2-sample-data magento2-sample-data-ee services-connector data-services services-id saas-export commerce-data-export commerce-data-export-ee magento-live-search data-solutions-magento-bff"
 INSTALLED_REPOS_B2B="magento2ce inventory magento2ee magento2b2b magento2-sample-data magento2-sample-data-ee services-connector data-services services-id saas-export commerce-data-export commerce-data-export-ee magento-live-search data-solutions-magento-bff"
 
+# if working with repos not yet in github, add them here
+#NEW_REPOS=""
+
 # options are [yes|no] - change to "no" when required repositories cloned!
 RECLONE=yes
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ MailHog is used to receive emails sent by Magento, navigate to http://localhost:
 :warning: Enabled Xdebug may slow your environment.  
 :exclamation: port `9003` is used for debug. 
 
+# How to configure PHPSTORM to use debugger for CLI commands:
+- Once xdebug in enabled, create a new PHP CLI Interpretor with SSH Configuration:
+![alt text](https://user-images.githubusercontent.com/2975006/181732593-507e7c09-e99f-40ec-b70e-a1403d13184e.png)
+
+- Then, create a new Run/Debug Configuration with path mapping:
+![alt text](https://user-images.githubusercontent.com/2975006/181730715-7d8cacd2-4810-4a0a-934b-35acc298b057.png)
+
+
 #### Magento (Re)-Installation
 
 * `docker-compose exec app magento reinstall`

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ MailHog is used to receive emails sent by Magento, navigate to http://localhost:
 - Then, create a new Run/Debug Configuration with path mapping:
 ![alt text](https://user-images.githubusercontent.com/2975006/181730715-7d8cacd2-4810-4a0a-934b-35acc298b057.png)
 
-
 #### Magento (Re)-Installation
 
 * `docker-compose exec app magento reinstall`

--- a/etc/php/tools/reinstall
+++ b/etc/php/tools/reinstall
@@ -27,6 +27,9 @@ if [[ ${MAGENTO_EDITION} == 'B2B' ]]; then
   repos=${INSTALLED_REPOS_B2B}
 fi
 
+# if working with repos not yet in github, add them here
+#repos="${repos} ${NEW_REPOS}"
+
 echo "$(date +"%T") Magento ${MAGENTO_EDITION} Installation START"
 
 for edition in $repos; do

--- a/mutagen.yml
+++ b/mutagen.yml
@@ -27,8 +27,8 @@ commands:
   logs: docker-compose logs --follow
   reindex: docker-compose exec app magento reindex
   reinstall: bash reinstall.sh
-  xdebug-enable: sed -ie "s|#zend_extension=xdebug.so|zend_extension=xdebug.so|" ./etc/php/xdebug.ini && docker-compose restart app web
-  xdebug-disable: sed -ie "s|zend_extension=xdebug.so|#zend_extension=xdebug.so|" ./etc/php/xdebug.ini && docker-compose restart app web
+  xdebug-enable: sed -i '' "s|#zend_extension = xdebug.so|zend_extension = xdebug.so|" ./etc/php/xdebug.ini && docker-compose restart app web
+  xdebug-disable: sed -i '' "s|zend_extension = xdebug.so|#zend_extension = xdebug.so|" ./etc/php/xdebug.ini && docker-compose restart app web
   grpc-server-start-monolith: docker-compose exec app magento grpc
 
 # Synchronize code to the shared Docker volume via the Mutagen service.


### PR DESCRIPTION
- Add Xdebug instruction for PHPStorm IDE
- Fix mutagen xdebug-enable and xdebug-disable command to make it work with mac os bash
- add NEW_REPOS variable, to be able to work with repos not in github (not cloning the code, but installing in var/www of the project)